### PR TITLE
Allow dots in origins

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -399,7 +399,7 @@ the directive are described by the following ABNF grammar:
 
 <pre dfn-type="grammar" link-type="grammar">
   directive-name  = "suborigin"
-  directive-value = 1*( <a>ALPHA</a> / <a>DIGIT</a> / "-" )
+  directive-value = 1*( <a>ALPHA</a> / <a>DIGIT</a> / "-" / "." )
 </pre>
 
 A resource's <dfn>suborigin namespace</dfn> is the value of the


### PR DESCRIPTION
Fixes: #8 

As discussed in #8, HTTP schema can contain a dot, so let's suborigins contain a dot as well.