### PR TITLE
Cleanup by removing bad syntax and fixing some origin examples.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -164,7 +164,7 @@ We see effectively three different use cases for Per-page Suborigins:
    messages stored within the account.
 
 <div class="example">
-  `https://example.com/` runs two applications, Chat and Shopping, used,
+  `https://example.com` runs two applications, Chat and Shopping, used,
   respectively, for instant messaging and Internet shopping.  The former is
   hosted at `https://example.com/chat/`, and the latter is hosted at
   `https://example.com/shopping/`.
@@ -368,13 +368,13 @@ but maintaining all of the information about both the original scheme, host,
 port, and the suborigin namespace. This is done by prepending the host name with
 the suborigin namespace followed by a "`_`" character.
 
-For example, if the resource is hosted at `https://example.com/` in
+For example, if the resource is hosted at `https://example.com` in
 the suborigin namespace `profile`, this would be serialized as
-`https://profile_example.com/`.
+`https://profile_example.com`.
 
-Similarly, if a resource is hosted at `https://example.com:8080/` in
+Similarly, if a resource is hosted at `https://example.com:8080` in
 the suborigin namespace `separate`, this would be serialized as
-`https://separate_example.com:8080/`.
+`https://separate_example.com:8080`.
 
 Internally, the <a>suborigin namespace</a> must be tracked by the user agent.
 When the origin needs to be serialized for a resource, the user agent should

--- a/index.bs
+++ b/index.bs
@@ -75,7 +75,6 @@ spec: URL; urlPrefix: https://url.spec.whatwg.org/
 }
 </pre>
 
-<!----------------------------------------------------------------------------->
 # Introduction # {#intro}
 
 <em>This section is not normative.</em>
@@ -222,8 +221,6 @@ We see effectively three different use cases for Per-page Suborigins:
 Issue: TODO: We probably should add additional examples, or perhaps match an
 example to each bullet above.
 
-<!----------------------------------------------------------------------------->
-
 # Key Concepts and Terminology # {#terms}
 
 Issue: TODO(jww) This needs to be filled in once we have a pretty good handle on
@@ -250,8 +247,6 @@ Cross-site Scripting</a> for more information.
 ## Grammatical Concepts ## {#grammar}
 The Augmented Backus-Naur Form (ABNF) notation used in this document is
 specified in RFC5234. [[!ABNF]]
-
-<!----------------------------------------------------------------------------->
 
 # Defining a Suborigin # {#defining-suborigin}
 
@@ -426,8 +421,6 @@ context. In there is no suborigin namespace, the value should be undefined.
 Additionally, the `origin` property of the <a>document</a> object should reflect
 the serialized value of the origin as returned by [[#serializing]].
 
-<!----------------------------------------------------------------------------->
-
 # Access Control # {#access-control}
 
 Cross-origin (including cross-suborigin) communication is tricky when suborigins
@@ -488,8 +481,6 @@ Note: This may change in the future, and Suborigins may eventually be allowed to
 register Service Workers, but for now, allowing the creation of Service Workers
 from Suborigins adds too many complications.
 
-<!----------------------------------------------------------------------------->
-
 # Impact on Web Platform # {#impact}
 
 Content inside a suborigin namespace is restricted in the same way that other
@@ -509,8 +500,6 @@ but a temporary restriction for practical purposes. It may be loosened in a
 future version of this spec.
 
 Issue: TODO(jww) Other restrictions? cookies? document.domain?
-
-<!----------------------------------------------------------------------------->
 
 # Framework # {#framework}
 
@@ -624,8 +613,6 @@ Issue: TODO(jww): Fill in sub sections for the various security model opt-outs.
 This includes document.cookie access, how event.origin is serialized in
 postMessage, localStorage sharing
 
-<!----------------------------------------------------------------------------->
-
 # Practical Considerations in Using Suborigins # {#practical-considerations}
 
 Using suborigins with a Web application should be relatively simple. At the most
@@ -649,8 +636,6 @@ used, the application must be modified so it does not check the
 `event.origin` field.  Instead, it should check
 `event.finerorigin` and additionally the `event.suborigin`
 fields, as they are defined in [[#postmessage-ac]].
-
-<!----------------------------------------------------------------------------->
 
 # Security Considerations # {#security-considerations}
 

--- a/index.html
+++ b/index.html
@@ -1220,8 +1220,8 @@ Traditional origin? (jww)</p>
  cannot be used to immediately infect other users or read their personal
  messages stored within the account.</p>
    </ol>
-   <div class="example" id="example-ead41676">
-    <a class="self-link" href="#example-ead41676"></a> <code>https://example.com/</code> runs two applications, Chat and Shopping, used,
+   <div class="example" id="example-3334caf3">
+    <a class="self-link" href="#example-3334caf3"></a> <code>https://example.com</code> runs two applications, Chat and Shopping, used,
   respectively, for instant messaging and Internet shopping.  The former is
   hosted at <code>https://example.com/chat/</code>, and the latter is hosted at <code>https://example.com/shopping/</code>. 
     <p>The Shopping application has been very well tested and generally does not
@@ -1366,10 +1366,10 @@ the suborigin namespace into the host of the Origin, thus creating a new host
 but maintaining all of the information about both the original scheme, host,
 port, and the suborigin namespace. This is done by prepending the host name with
 the suborigin namespace followed by a "<code>_</code>" character.</p>
-   <p>For example, if the resource is hosted at <code>https://example.com/</code> in
-the suborigin namespace <code>profile</code>, this would be serialized as <code>https://profile_example.com/</code>.</p>
-   <p>Similarly, if a resource is hosted at <code>https://example.com:8080/</code> in
-the suborigin namespace <code>separate</code>, this would be serialized as <code>https://separate_example.com:8080/</code>.</p>
+   <p>For example, if the resource is hosted at <code>https://example.com</code> in
+the suborigin namespace <code>profile</code>, this would be serialized as <code>https://profile_example.com</code>.</p>
+   <p>Similarly, if a resource is hosted at <code>https://example.com:8080</code> in
+the suborigin namespace <code>separate</code>, this would be serialized as <code>https://separate_example.com:8080</code>.</p>
    <p>Internally, the <a data-link-type="dfn" href="#suborigin-namespace">suborigin namespace</a> must be tracked by the user agent.
 When the origin needs to be serialized for a resource, the user agent should
 follow the algorithm in <a href="#serializing">§6.3 Serializing Suborigins</a>.</p>

--- a/index.html
+++ b/index.html
@@ -1000,7 +1000,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Suborigins</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-01-29">29 January 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-02-18">18 February 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:


### PR DESCRIPTION
This should address #14 by removing all of the invalid comments, which were completely extraneous anyway.