### PR TITLE
Force include credentials

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -38,6 +38,8 @@ spec: CORS; urlPrefix: https://www.w3.org/TR/cors
 
 spec: Fetch; urlPrefix: https://fetch.spec.whatwg.org
   type: dfn
+    text: credentials; url: credentials
+    text: credentials mode; url: concept-request-credentials-mode
     text: fetch; url: concept-fetch
     text: request; url: concept-request
     text: response type; url: concept-response-type
@@ -722,6 +724,13 @@ spec:dom-ls; type:interface; text:Document
   The values of <a link-type="grammar">suborigin-policy-option</a> that may be
   present in a <a>suborigin policy</a> have the following effects:
 
+  * '<dfn>`force-include-credentials`</dfn>' All cross-origin requests will
+    include <a>credentials</a>. In particular, when this option is set, all
+    <a>requests</a> will have their <a>credentials mode</a> set to "`include`".
+    See <a
+    href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
+    protocol and credentials</a> for mor 
+
   * '<dfn>`unsafe-cookies`</dfn>' When an execution context with a suborigin
     namespace has <a>`unsafe-cookies`</a> set, the
     execution context should not have a fresh cookie jar for the suborigin
@@ -742,14 +751,14 @@ spec:dom-ls; type:interface; text:Document
     <div class="example">
     Continuing the case in the above example, `https://example.com/maps` is a
     mapping application that is commonly embedded in other sites. It provides a
-    `postMessage()` based API to place locations of the embedder's choosing on the
-    map. `httsp://example.com` would like to run the application in a suborigin
-    named "maps".
+    `postMessage()` based API to place locations of the embedder's
+    choosing on the map. `https://example.com` would like to run the application
+    in a suborigin named "maps".
 
     In response to queries to the API, `https://example.com/maps` may send
     messages back to the embedder if, for example, a user clicks on one of the
     locations. However, since the embedder may be legacy and not be aware of
-    suborigins, when it checks the `event.origin` protery of the
+    suborigins, when it checks the `event.origin` property of the
     `MesseageEvent`, if it sees `https-so://maps.example.com` as the origin, it
     will reject the message as a potential attack. Thus, `https://example.com`
     may use the <a>`unsafe-postmessage-send`</a> directive to allow its messages

--- a/index.bs
+++ b/index.bs
@@ -731,6 +731,8 @@ spec:dom-ls; type:interface; text:Document
     href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
     protocol and credentials</a> for more on including credentials.
 
+    Issue: TODO(jww): Provide an example of why this might be needed.
+
   * '<dfn>`unsafe-cookies`</dfn>' When an execution context with a suborigin
     namespace has <a>`unsafe-cookies`</a> set, the
     execution context should not have a fresh cookie jar for the suborigin

--- a/index.bs
+++ b/index.bs
@@ -782,15 +782,20 @@ spec:dom-ls; type:interface; text:Document
     dangerous and should not be used if you have Real Deal auth and csrf cookies
     used.
 
-   * '<dfn>`unsafe-include-credentials`</dfn>' All cross-origin requests will
-     include <a>credentials</a>. In particular, when this option is set in an
-     execution context, all cross-origin <a>requests</a> from that execution
-     context will have their <a>credentials mode</a> set to "`include`".  See <a
+   * '<dfn>`unsafe-include-credentials`</dfn>' All cross-origin requests to the
+     <a>physical origin</a> for the execution context will include
+     <a>credentials</a>. In particular, when this option is set in an execution
+     context, all cross-origin <a>requests</a> from that execution context to
+     the <a>physical origin</a> will have their <a>credentials mode</a> set to
+     "`include`". Additionally, if the <a>credentials mode</a> is
+     programmitically set, it will still be overriden to be set to "`include`".
+
+     See <a
      href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
      protocol and credentials</a> for more on including credentials and the
      implications of including credentials in requests.
  
-     Issue: TODO(jww): Provide an example of why this might be needed.
+     Issue: TODO(jww,aaj): Provide an example of why this might be needed.
 
   Issue: TODO: These opt-out descriptions should probably be moved to the
   individual sections where the behaviors are discussed (i.e. postMessage and

--- a/index.bs
+++ b/index.bs
@@ -790,11 +790,14 @@ spec:dom-ls; type:interface; text:Document
      "`include`". Additionally, if the <a>credentials mode</a> is
      programmitically set, it will still be overriden to be set to "`include`".
 
-     See <a
+     Note: This applies to <em>all</em> cross-origin requests, not just
+     `xmlHttpRequests` and `fetch` requests. Thus all cross-origin elements on
+     the page, including, for example, image tags, will have the equivalement of
+     the `crossorigin` attribute set to "`use-credentials`". See <a
      href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
      protocol and credentials</a> for more on including credentials and the
      implications of including credentials in requests.
- 
+
      Issue: TODO(jww,aaj): Provide an example of why this might be needed.
 
   Issue: TODO: These opt-out descriptions should probably be moved to the

--- a/index.bs
+++ b/index.bs
@@ -725,11 +725,12 @@ spec:dom-ls; type:interface; text:Document
   present in a <a>suborigin policy</a> have the following effects:
 
   * '<dfn>`force-include-credentials`</dfn>' All cross-origin requests will
-    include <a>credentials</a>. In particular, when this option is set, all
-    cross-origin <a>requests</a> will have their <a>credentials mode</a> set to
-    "`include`".  See <a
+    include <a>credentials</a>. In particular, when this option is set in an
+    execution context, all cross-origin <a>requests</a> from that execution
+    context will have their <a>credentials mode</a> set to "`include`".  See <a
     href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
-    protocol and credentials</a> for more on including credentials.
+    protocol and credentials</a> for more on including credentials and the
+    implications of including credentials in requests.
 
     Issue: TODO(jww): Provide an example of why this might be needed.
 

--- a/index.bs
+++ b/index.bs
@@ -443,9 +443,10 @@ spec:dom-ls; type:interface; text:Document
 
   <pre dfn-type="grammar" link-type="grammar">
       <dfn>suborigin-name</dfn> = 1*( <a>LOWERALPHA</a> / <a>DIGIT</a> / "-" )
-      <dfn>suborigin-policy-option</dfn> = "'unsafe-postmessage-send'"
-                                / "'unsafe-postmessage-receive'"
+      <dfn>suborigin-policy-option</dfn> = "'force-include-credentials'"
                                 / "'unsafe-cookies'"
+                                / "'unsafe-postmessage-receive'"
+                                / "'unsafe-postmessage-send'"
       <dfn>suborigin-policy-list</dfn> = 1*(<a>RWS</a> <a>suborigin-policy-option</a> <a>OWS</a>)
       <dfn>suborigin-header</dfn> = <a>suborigin-name</a> [ <a>suborigin-policy-list</a> ]
   </pre>
@@ -721,28 +722,15 @@ spec:dom-ls; type:interface; text:Document
   The values of <a link-type="grammar">suborigin-policy-option</a> that may be
   present in a <a>suborigin policy</a> have the following effects:
 
-  * '<dfn>`unsafe-postmessage-receive`</dfn>' When a message is sent <i>to</i> a
-    frame with a `postMessage` `target` of a serialized physical origin, but not a
-    serialized suborigin, if the frame has an execution context with a suborigin
-    where the scheme, host, and port match the `target`, but it also has a
-    suborigin namespace, if <a>`unsafe-postmessage-receive`</a> is set, it will
-    still receive the message.
+  * '<dfn>`unsafe-cookies`</dfn>' When an execution context with a suborigin
+    namespace has <a>`unsafe-cookies`</a> set, the
+    execution context should not have a fresh cookie jar for the suborigin
+    namespace, and instead, the cookie jar should be shared with the null
+    suborigin for the execution context.
 
-    <div class="example" id="unsafe-postmessage-send-ex">
-    `https://example.com` runs a map API at `https://example.com/maps` which is
-    embedded by many other websites. It provides a `postMessage()` API to place
-    markers on the map at locations the embedder chooses.
-
-    The developer would like to run `https://example.com/maps` in a suborigin
-    namespace "maps".  However, when embedders send messages to the embedded
-    frame, because they are legacy uses from before the use of suborigins, they
-    send essages with a `target` of `https://example.com`, <em>not</em>
-    `https-so://maps.example.com`. Since the developer would still like this
-    frame to be able to provide the API to these legacy embedders, it can serve
-    the frame with the <a>`unsafe-postmessage-receive`</a> directive, which will
-    allow the frame to receive messages on behalf of `https://example.com`, even
-    though it is at `https-so://maps.example.com`.
-    </div>
+    Issue: TODO(devd): Write an example that makes clear that this is extremely
+    dangerous and should not be used if you have Real Deal auth and csrf cookies
+    used.
 
   * '<dfn>`unsafe-postmessage-send`</dfn>' When a message is sent <i>from</i> a
     suborigin namespace with <a>`unsafe-postmessage-send`</a> set, the
@@ -769,15 +757,28 @@ spec:dom-ls; type:interface; text:Document
     `https://example.com`.
     </div>
 
-  * '<dfn>`unsafe-cookies`</dfn>' When an execution context with a suborigin
-    namespace has <a>`unsafe-cookies`</a> set, the
-    execution context should not have a fresh cookie jar for the suborigin
-    namespace, and instead, the cookie jar should be shared with the null
-    suborigin for the execution context.
+  * '<dfn>`unsafe-postmessage-receive`</dfn>' When a message is sent <i>to</i> a
+    frame with a `postMessage` `target` of a serialized physical origin, but not a
+    serialized suborigin, if the frame has an execution context with a suborigin
+    where the scheme, host, and port match the `target`, but it also has a
+    suborigin namespace, if <a>`unsafe-postmessage-receive`</a> is set, it will
+    still receive the message.
 
-    Issue: TODO(devd): Write an example that makes clear that this is extremely
-    dangerous and should not be used if you have Real Deal auth and csrf cookies
-    used.
+    <div class="example" id="unsafe-postmessage-send-ex">
+    `https://example.com` runs a map API at `https://example.com/maps` which is
+    embedded by many other websites. It provides a `postMessage()` API to place
+    markers on the map at locations the embedder chooses.
+
+    The developer would like to run `https://example.com/maps` in a suborigin
+    namespace "maps".  However, when embedders send messages to the embedded
+    frame, because they are legacy uses from before the use of suborigins, they
+    send essages with a `target` of `https://example.com`, <em>not</em>
+    `https-so://maps.example.com`. Since the developer would still like this
+    frame to be able to provide the API to these legacy embedders, it can serve
+    the frame with the <a>`unsafe-postmessage-receive`</a> directive, which will
+    allow the frame to receive messages on behalf of `https://example.com`, even
+    though it is at `https-so://maps.example.com`.
+    </div>
 
   Issue: TODO: These opt-out descriptions should probably be moved to the
   individual sections where the behaviors are discussed (i.e. postMessage and

--- a/index.bs
+++ b/index.bs
@@ -726,8 +726,8 @@ spec:dom-ls; type:interface; text:Document
 
   * '<dfn>`force-include-credentials`</dfn>' All cross-origin requests will
     include <a>credentials</a>. In particular, when this option is set, all
-    <a>requests</a> will have their <a>credentials mode</a> set to "`include`".
-    See <a
+    cross-origin <a>requests</a> will have their <a>credentials mode</a> set to
+    "`include`".  See <a
     href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
     protocol and credentials</a> for more on including credentials.
 

--- a/index.bs
+++ b/index.bs
@@ -38,8 +38,6 @@ spec: CORS; urlPrefix: https://www.w3.org/TR/cors
 
 spec: Fetch; urlPrefix: https://fetch.spec.whatwg.org
   type: dfn
-    text: credentials; url: credentials
-    text: credentials mode; url: concept-request-credentials-mode
     text: fetch; url: concept-fetch
     text: request; url: concept-request
     text: response type; url: concept-response-type
@@ -445,10 +443,9 @@ spec:dom-ls; type:interface; text:Document
 
   <pre dfn-type="grammar" link-type="grammar">
       <dfn>suborigin-name</dfn> = 1*( <a>LOWERALPHA</a> / <a>DIGIT</a> / "-" )
-      <dfn>suborigin-policy-option</dfn> = "'force-include-credentials'"
-                                / "'unsafe-cookies'"
+      <dfn>suborigin-policy-option</dfn> = "'unsafe-postmessage-send'"
                                 / "'unsafe-postmessage-receive'"
-                                / "'unsafe-postmessage-send'"
+                                / "'unsafe-cookies'"
       <dfn>suborigin-policy-list</dfn> = 1*(<a>RWS</a> <a>suborigin-policy-option</a> <a>OWS</a>)
       <dfn>suborigin-header</dfn> = <a>suborigin-name</a> [ <a>suborigin-policy-list</a> ]
   </pre>
@@ -724,50 +721,6 @@ spec:dom-ls; type:interface; text:Document
   The values of <a link-type="grammar">suborigin-policy-option</a> that may be
   present in a <a>suborigin policy</a> have the following effects:
 
-  * '<dfn>`force-include-credentials`</dfn>' All cross-origin requests will
-    include <a>credentials</a>. In particular, when this option is set in an
-    execution context, all cross-origin <a>requests</a> from that execution
-    context will have their <a>credentials mode</a> set to "`include`".  See <a
-    href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
-    protocol and credentials</a> for more on including credentials and the
-    implications of including credentials in requests.
-
-    Issue: TODO(jww): Provide an example of why this might be needed.
-
-  * '<dfn>`unsafe-cookies`</dfn>' When an execution context with a suborigin
-    namespace has <a>`unsafe-cookies`</a> set, the
-    execution context should not have a fresh cookie jar for the suborigin
-    namespace, and instead, the cookie jar should be shared with the null
-    suborigin for the execution context.
-
-    Issue: TODO(devd): Write an example that makes clear that this is extremely
-    dangerous and should not be used if you have Real Deal auth and csrf cookies
-    used.
-
-  * '<dfn>`unsafe-postmessage-send`</dfn>' When a message is sent <i>from</i> a
-    suborigin namespace with <a>`unsafe-postmessage-send`</a> set, the
-    `event.origin` value of the receiver should be set to the serialized
-    physical origin, not the serialized suborigin value. However, the
-    `event.suborigin` field should still be set to the name of the suborigin
-    namespace.
-
-    <div class="example">
-    `https://example.com/maps` is a mapping application that is commonly
-    embedded in other sites. It provides a `postMessage()` based API to place
-    locations of the embedder's choosing on the map. `https://example.com` would
-    like to run the application in a suborigin named "maps".
-
-    In response to queries to the API, `https://example.com/maps` may send
-    messages back to the embedder if, for example, a user clicks on one of the
-    locations. However, since the embedder may be legacy and not be aware of
-    suborigins, when it checks the `event.origin` property of the
-    `MesseageEvent`, if it sees `https-so://maps.example.com` as the origin, it
-    will reject the message as a potential attack. Thus, `https://example.com`
-    may use the <a>`unsafe-postmessage-send`</a> directive to allow its messages
-    to appear with the origin of the physical origin, in this case
-    `https://example.com`.
-    </div>
-
   * '<dfn>`unsafe-postmessage-receive`</dfn>' When a message is sent <i>to</i> a
     frame with a `postMessage` `target` of a serialized physical origin, but not a
     serialized suborigin, if the frame has an execution context with a suborigin
@@ -776,10 +729,9 @@ spec:dom-ls; type:interface; text:Document
     still receive the message.
 
     <div class="example" id="unsafe-postmessage-send-ex">
-    Continuing the example from above, assume `https://example.com` runs a map
-    API at `https://example.com/maps` which is embedded by many other websites.
-    It provides a `postMessage()` API to place markers on the map at locations
-    the embedder chooses.
+    `https://example.com` runs a map API at `https://example.com/maps` which is
+    embedded by many other websites. It provides a `postMessage()` API to place
+    markers on the map at locations the embedder chooses.
 
     The developer would like to run `https://example.com/maps` in a suborigin
     namespace "maps".  However, when embedders send messages to the embedded
@@ -791,6 +743,41 @@ spec:dom-ls; type:interface; text:Document
     allow the frame to receive messages on behalf of `https://example.com`, even
     though it is at `https-so://maps.example.com`.
     </div>
+
+  * '<dfn>`unsafe-postmessage-send`</dfn>' When a message is sent <i>from</i> a
+    suborigin namespace with <a>`unsafe-postmessage-send`</a> set, the
+    `event.origin` value of the receiver should be set to the serialized
+    physical origin, not the serialized suborigin value. However, the
+    `event.suborigin` field should still be set to the name of the suborigin
+    namespace.
+
+    <div class="example">
+    Continuing the case in the above example, `https://example.com/maps` is a
+    mapping application that is commonly embedded in other sites. It provides a
+    `postMessage()` based API to place locations of the embedder's choosing on the
+    map. `httsp://example.com` would like to run the application in a suborigin
+    named "maps".
+
+    In response to queries to the API, `https://example.com/maps` may send
+    messages back to the embedder if, for example, a user clicks on one of the
+    locations. However, since the embedder may be legacy and not be aware of
+    suborigins, when it checks the `event.origin` protery of the
+    `MesseageEvent`, if it sees `https-so://maps.example.com` as the origin, it
+    will reject the message as a potential attack. Thus, `https://example.com`
+    may use the <a>`unsafe-postmessage-send`</a> directive to allow its messages
+    to appear with the origin of the physical origin, in this case
+    `https://example.com`.
+    </div>
+
+  * '<dfn>`unsafe-cookies`</dfn>' When an execution context with a suborigin
+    namespace has <a>`unsafe-cookies`</a> set, the
+    execution context should not have a fresh cookie jar for the suborigin
+    namespace, and instead, the cookie jar should be shared with the null
+    suborigin for the execution context.
+
+    Issue: TODO(devd): Write an example that makes clear that this is extremely
+    dangerous and should not be used if you have Real Deal auth and csrf cookies
+    used.
 
   Issue: TODO: These opt-out descriptions should probably be moved to the
   individual sections where the behaviors are discussed (i.e. postMessage and

--- a/index.bs
+++ b/index.bs
@@ -729,7 +729,7 @@ spec:dom-ls; type:interface; text:Document
     <a>requests</a> will have their <a>credentials mode</a> set to "`include`".
     See <a
     href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
-    protocol and credentials</a> for mor 
+    protocol and credentials</a> for more on including credentials.
 
   * '<dfn>`unsafe-cookies`</dfn>' When an execution context with a suborigin
     namespace has <a>`unsafe-cookies`</a> set, the
@@ -749,11 +749,10 @@ spec:dom-ls; type:interface; text:Document
     namespace.
 
     <div class="example">
-    Continuing the case in the above example, `https://example.com/maps` is a
-    mapping application that is commonly embedded in other sites. It provides a
-    `postMessage()` based API to place locations of the embedder's
-    choosing on the map. `https://example.com` would like to run the application
-    in a suborigin named "maps".
+    `https://example.com/maps` is a mapping application that is commonly
+    embedded in other sites. It provides a `postMessage()` based API to place
+    locations of the embedder's choosing on the map. `https://example.com` would
+    like to run the application in a suborigin named "maps".
 
     In response to queries to the API, `https://example.com/maps` may send
     messages back to the embedder if, for example, a user clicks on one of the
@@ -774,9 +773,10 @@ spec:dom-ls; type:interface; text:Document
     still receive the message.
 
     <div class="example" id="unsafe-postmessage-send-ex">
-    `https://example.com` runs a map API at `https://example.com/maps` which is
-    embedded by many other websites. It provides a `postMessage()` API to place
-    markers on the map at locations the embedder chooses.
+    Continuing the example from above, assume `https://example.com` runs a map
+    API at `https://example.com/maps` which is embedded by many other websites.
+    It provides a `postMessage()` API to place markers on the map at locations
+    the embedder chooses.
 
     The developer would like to run `https://example.com/maps` in a suborigin
     namespace "maps".  However, when embedders send messages to the embedded

--- a/index.bs
+++ b/index.bs
@@ -38,6 +38,8 @@ spec: CORS; urlPrefix: https://www.w3.org/TR/cors
 
 spec: Fetch; urlPrefix: https://fetch.spec.whatwg.org
   type: dfn
+    text: credentials; url: credentials
+    text: credentials mode; url: concept-request-credentials-mode
     text: fetch; url: concept-fetch
     text: request; url: concept-request
     text: response type; url: concept-response-type
@@ -446,6 +448,7 @@ spec:dom-ls; type:interface; text:Document
       <dfn>suborigin-policy-option</dfn> = "'unsafe-postmessage-send'"
                                 / "'unsafe-postmessage-receive'"
                                 / "'unsafe-cookies'"
+                                / "'unsafe-include-credentials'"
       <dfn>suborigin-policy-list</dfn> = 1*(<a>RWS</a> <a>suborigin-policy-option</a> <a>OWS</a>)
       <dfn>suborigin-header</dfn> = <a>suborigin-name</a> [ <a>suborigin-policy-list</a> ]
   </pre>
@@ -778,6 +781,16 @@ spec:dom-ls; type:interface; text:Document
     Issue: TODO(devd): Write an example that makes clear that this is extremely
     dangerous and should not be used if you have Real Deal auth and csrf cookies
     used.
+
+   * '<dfn>`unsafe-include-credentials`</dfn>' All cross-origin requests will
+     include <a>credentials</a>. In particular, when this option is set in an
+     execution context, all cross-origin <a>requests</a> from that execution
+     context will have their <a>credentials mode</a> set to "`include`".  See <a
+     href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
+     protocol and credentials</a> for more on including credentials and the
+     implications of including credentials in requests.
+ 
+     Issue: TODO(jww): Provide an example of why this might be needed.
 
   Issue: TODO: These opt-out descriptions should probably be moved to the
   individual sections where the behaviors are discussed (i.e. postMessage and

--- a/index.html
+++ b/index.html
@@ -1363,7 +1363,7 @@ Possible extra rowspan handling
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Suborigins</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-04">4 October 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-10">10 October 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1786,6 +1786,7 @@ This includes providing security-model opt-outs where necessary.</p>
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-suborigin-policy-option">suborigin-policy-option</dfn> = "'unsafe-postmessage-send'"
                           / "'unsafe-postmessage-receive'"
                           / "'unsafe-cookies'"
+                          / "'unsafe-include-credentials'"
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-suborigin-policy-list">suborigin-policy-list</dfn> = 1*(<a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3">RWS</a> <a data-link-type="grammar" href="#grammardef-suborigin-policy-option" id="ref-for-grammardef-suborigin-policy-option-1">suborigin-policy-option</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3">OWS</a>)
 <dfn data-dfn-type="grammar" data-export="" id="grammardef-suborigin-header">suborigin-header<a class="self-link" href="#grammardef-suborigin-header"></a></dfn> = <a data-link-type="grammar" href="#grammardef-suborigin-name" id="ref-for-grammardef-suborigin-name-1">suborigin-name</a> [ <a data-link-type="grammar" href="#grammardef-suborigin-policy-list" id="ref-for-grammardef-suborigin-policy-list-1">suborigin-policy-list</a> ]
 </pre>
@@ -2026,6 +2027,14 @@ suborigin for the execution context.</p>
      <p class="issue" id="issue-a4bfe642"><a class="self-link" href="#issue-a4bfe642"></a> TODO(devd): Write an example that makes clear that this is extremely
 dangerous and should not be used if you have Real Deal auth and csrf cookies
 used.</p>
+    <li data-md="">
+     <p>'<dfn data-dfn-type="dfn" data-noexport="" id="unsafe-include-credentials"><code>unsafe-include-credentials</code><a class="self-link" href="#unsafe-include-credentials"></a></dfn>' All cross-origin requests will
+ include <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#credentials">credentials</a>. In particular, when this option is set in an
+ execution context, all cross-origin <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request">requests</a> from that execution
+ context will have their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a> set to "<code>include</code>".  See <a href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
+ protocol and credentials</a> for more on including credentials and the
+ implications of including credentials in requests.</p>
+     <p class="issue" id="issue-eae464e1"><a class="self-link" href="#issue-eae464e1"></a> TODO(jww): Provide an example of why this might be needed.</p>
    </ul>
    <p class="issue" id="issue-01de7cd9"><a class="self-link" href="#issue-01de7cd9"></a> TODO: These opt-out descriptions should probably be moved to the
   individual sections where the behaviors are discussed (i.e. postMessage and
@@ -2121,6 +2130,7 @@ used.</p>
    <li><a href="#grammardef-suborigin-policy-list">suborigin-policy-list</a><span>, in §3.6</span>
    <li><a href="#grammardef-suborigin-policy-option">suborigin-policy-option</a><span>, in §3.6</span>
    <li><a href="#unsafe-cookies">unsafe-cookies</a><span>, in §6.5</span>
+   <li><a href="#unsafe-include-credentials">unsafe-include-credentials</a><span>, in §6.5</span>
    <li><a href="#unsafe-postmessage-receive">unsafe-postmessage-receive</a><span>, in §6.5</span>
    <li><a href="#unsafe-postmessage-send">unsafe-postmessage-send</a><span>, in §6.5</span>
    <li><a href="#xhr">XHR</a><span>, in §2</span>
@@ -2150,7 +2160,10 @@ used.</p>
    <li>
     <a data-link-type="biblio">[FETCH]</a> defines the following terms:
     <ul>
+     <li><a href="https://fetch.spec.whatwg.org#credentials">credentials</a>
+     <li><a href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a>
      <li><a href="https://fetch.spec.whatwg.org#concept-fetch">fetch</a>
+     <li><a href="https://fetch.spec.whatwg.org#concept-request">request</a>
     </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
@@ -2257,6 +2270,7 @@ used.</p>
    <div class="issue"> TODO(devd): Write an example that makes clear that this is extremely
 dangerous and should not be used if you have Real Deal auth and csrf cookies
 used.<a href="#issue-a4bfe642"> ↵ </a></div>
+   <div class="issue"> TODO(jww): Provide an example of why this might be needed.<a href="#issue-eae464e1"> ↵ </a></div>
    <div class="issue"> TODO: These opt-out descriptions should probably be moved to the
   individual sections where the behaviors are discussed (i.e. postMessage and
   cookies). These just need to be fleshed out anyway, and examples and reasons

--- a/index.html
+++ b/index.html
@@ -1983,8 +1983,9 @@ the '<a data-link-type="dfn" href="#unsafe-cookies" id="ref-for-unsafe-cookies-1
    <ul>
     <li data-md="">
      <p>'<dfn data-dfn-type="dfn" data-noexport="" id="force-include-credentials"><code>force-include-credentials</code><a class="self-link" href="#force-include-credentials"></a></dfn>' All cross-origin requests will
-include <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#credentials">credentials</a>. In particular, when this option is set, all <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request">requests</a> will have their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a> set to "<code>include</code>".
-See <a href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
+include <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#credentials">credentials</a>. In particular, when this option is set, all
+cross-origin <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request">requests</a> will have their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a> set to
+"<code>include</code>".  See <a href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
 protocol and credentials</a> for more on including credentials.</p>
      <p class="issue" id="issue-eae464e1"><a class="self-link" href="#issue-eae464e1"></a> TODO(jww): Provide an example of why this might be needed.</p>
     <li data-md="">

--- a/index.html
+++ b/index.html
@@ -1986,6 +1986,7 @@ the '<a data-link-type="dfn" href="#unsafe-cookies" id="ref-for-unsafe-cookies-1
 include <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#credentials">credentials</a>. In particular, when this option is set, all <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request">requests</a> will have their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a> set to "<code>include</code>".
 See <a href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
 protocol and credentials</a> for more on including credentials.</p>
+     <p class="issue" id="issue-eae464e1"><a class="self-link" href="#issue-eae464e1"></a> TODO(jww): Provide an example of why this might be needed.</p>
     <li data-md="">
      <p>'<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unsafe-cookies"><code>unsafe-cookies</code></dfn>' When an execution context with a suborigin
 namespace has <a data-link-type="dfn" href="#unsafe-cookies" id="ref-for-unsafe-cookies-2"><code>unsafe-cookies</code></a> set, the
@@ -2265,6 +2266,7 @@ though it is at <code>https-so://maps.example.com</code>.</p>
    <div class="issue"> TODO: This section should probably be broken up. At the very least,
   needs to be formalized. Maybe just stick with creating a new execution
   context, and then carving out the weird exceptions?<a href="#issue-73e47fd0"> ↵ </a></div>
+   <div class="issue"> TODO(jww): Provide an example of why this might be needed.<a href="#issue-eae464e1"> ↵ </a></div>
    <div class="issue"> TODO(devd): Write an example that makes clear that this is extremely
 dangerous and should not be used if you have Real Deal auth and csrf cookies
 used.<a href="#issue-a4bfe642"> ↵ </a></div>

--- a/index.html
+++ b/index.html
@@ -2028,13 +2028,15 @@ suborigin for the execution context.</p>
 dangerous and should not be used if you have Real Deal auth and csrf cookies
 used.</p>
     <li data-md="">
-     <p>'<dfn data-dfn-type="dfn" data-noexport="" id="unsafe-include-credentials"><code>unsafe-include-credentials</code><a class="self-link" href="#unsafe-include-credentials"></a></dfn>' All cross-origin requests will
- include <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#credentials">credentials</a>. In particular, when this option is set in an
- execution context, all cross-origin <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request">requests</a> from that execution
- context will have their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a> set to "<code>include</code>".  See <a href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
+     <p>'<dfn data-dfn-type="dfn" data-noexport="" id="unsafe-include-credentials"><code>unsafe-include-credentials</code><a class="self-link" href="#unsafe-include-credentials"></a></dfn>' All cross-origin requests to the <a data-link-type="dfn" href="#physical-origin" id="ref-for-physical-origin-2">physical origin</a> for the execution context will include <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#credentials">credentials</a>. In particular, when this option is set in an execution
+ context, all cross-origin <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request">requests</a> from that execution context to
+ the <a data-link-type="dfn" href="#physical-origin" id="ref-for-physical-origin-3">physical origin</a> will have their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a> set to
+ "<code>include</code>". Additionally, if the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a> is
+ programmitically set, it will still be overriden to be set to "<code>include</code>".</p>
+     <p>See <a href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
  protocol and credentials</a> for more on including credentials and the
  implications of including credentials in requests.</p>
-     <p class="issue" id="issue-eae464e1"><a class="self-link" href="#issue-eae464e1"></a> TODO(jww): Provide an example of why this might be needed.</p>
+     <p class="issue" id="issue-ec925137"><a class="self-link" href="#issue-ec925137"></a> TODO(jww,aaj): Provide an example of why this might be needed.</p>
    </ul>
    <p class="issue" id="issue-01de7cd9"><a class="self-link" href="#issue-01de7cd9"></a> TODO: These opt-out descriptions should probably be moved to the
   individual sections where the behaviors are discussed (i.e. postMessage and
@@ -2270,7 +2272,7 @@ used.</p>
    <div class="issue"> TODO(devd): Write an example that makes clear that this is extremely
 dangerous and should not be used if you have Real Deal auth and csrf cookies
 used.<a href="#issue-a4bfe642"> ↵ </a></div>
-   <div class="issue"> TODO(jww): Provide an example of why this might be needed.<a href="#issue-eae464e1"> ↵ </a></div>
+   <div class="issue"> TODO(jww,aaj): Provide an example of why this might be needed.<a href="#issue-ec925137"> ↵ </a></div>
    <div class="issue"> TODO: These opt-out descriptions should probably be moved to the
   individual sections where the behaviors are discussed (i.e. postMessage and
   cookies). These just need to be fleshed out anyway, and examples and reasons
@@ -2321,6 +2323,7 @@ used.<a href="#issue-a4bfe642"> ↵ </a></div>
    <b><a href="#physical-origin">#physical-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical-origin-1">6.4.1. Cookies</a>
+    <li><a href="#ref-for-physical-origin-2">6.5. Security Model Opt-Outs</a> <a href="#ref-for-physical-origin-3">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="suborigin">

--- a/index.html
+++ b/index.html
@@ -1985,7 +1985,7 @@ the '<a data-link-type="dfn" href="#unsafe-cookies" id="ref-for-unsafe-cookies-1
      <p>'<dfn data-dfn-type="dfn" data-noexport="" id="force-include-credentials"><code>force-include-credentials</code><a class="self-link" href="#force-include-credentials"></a></dfn>' All cross-origin requests will
 include <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#credentials">credentials</a>. In particular, when this option is set, all <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request">requests</a> will have their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a> set to "<code>include</code>".
 See <a href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
-protocol and credentials</a> for mor</p>
+protocol and credentials</a> for more on including credentials.</p>
     <li data-md="">
      <p>'<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unsafe-cookies"><code>unsafe-cookies</code></dfn>' When an execution context with a suborigin
 namespace has <a data-link-type="dfn" href="#unsafe-cookies" id="ref-for-unsafe-cookies-2"><code>unsafe-cookies</code></a> set, the
@@ -2000,11 +2000,11 @@ used.</p>
 suborigin namespace with <a data-link-type="dfn" href="#unsafe-postmessage-send" id="ref-for-unsafe-postmessage-send-1"><code>unsafe-postmessage-send</code></a> set, the <code>event.origin</code> value of the receiver should be set to the serialized
 physical origin, not the serialized suborigin value. However, the <code>event.suborigin</code> field should still be set to the name of the suborigin
 namespace.</p>
-     <div class="example" id="example-231b0547">
-      <a class="self-link" href="#example-231b0547"></a> Continuing the case in the above example, <code>https://example.com/maps</code> is a
-mapping application that is commonly embedded in other sites. It provides a <code>postMessage()</code> based API to place locations of the embedder’s
-choosing on the map. <code>https://example.com</code> would like to run the application
-in a suborigin named "maps". 
+     <div class="example" id="example-b711d6b9">
+      <a class="self-link" href="#example-b711d6b9"></a> <code>https://example.com/maps</code> is a mapping application that is commonly
+embedded in other sites. It provides a <code>postMessage()</code> based API to place
+locations of the embedder’s choosing on the map. <code>https://example.com</code> would
+like to run the application in a suborigin named "maps". 
       <p>In response to queries to the API, <code>https://example.com/maps</code> may send
 messages back to the embedder if, for example, a user clicks on one of the
 locations. However, since the embedder may be legacy and not be aware of
@@ -2020,9 +2020,10 @@ where the scheme, host, and port match the <code>target</code>, but it also has 
 suborigin namespace, if <a data-link-type="dfn" href="#unsafe-postmessage-receive" id="ref-for-unsafe-postmessage-receive-1"><code>unsafe-postmessage-receive</code></a> is set, it will
 still receive the message.</p>
      <div class="example" id="unsafe-postmessage-send-ex">
-      <a class="self-link" href="#unsafe-postmessage-send-ex"></a> <code>https://example.com</code> runs a map API at <code>https://example.com/maps</code> which is
-embedded by many other websites. It provides a <code>postMessage()</code> API to place
-markers on the map at locations the embedder chooses. 
+      <a class="self-link" href="#unsafe-postmessage-send-ex"></a> Continuing the example from above, assume <code>https://example.com</code> runs a map
+API at <code>https://example.com/maps</code> which is embedded by many other websites.
+It provides a <code>postMessage()</code> API to place markers on the map at locations
+the embedder chooses. 
       <p>The developer would like to run <code>https://example.com/maps</code> in a suborigin
 namespace "maps".  However, when embedders send messages to the embedded
 frame, because they are legacy uses from before the use of suborigins, they

--- a/index.html
+++ b/index.html
@@ -1363,7 +1363,7 @@ Possible extra rowspan handling
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Suborigins</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-04">4 October 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-10">10 October 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1783,9 +1783,10 @@ This includes providing security-model opt-outs where necessary.</p>
   for the name and value of the header are described by the following ABNF
   grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-suborigin-name">suborigin-name</dfn> = 1*( <a data-link-type="grammar" href="#grammardef-loweralpha" id="ref-for-grammardef-loweralpha-1">LOWERALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1">DIGIT</a> / "-" )
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-suborigin-policy-option">suborigin-policy-option</dfn> = "'unsafe-postmessage-send'"
-                          / "'unsafe-postmessage-receive'"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-suborigin-policy-option">suborigin-policy-option</dfn> = "'force-include-credentials'"
                           / "'unsafe-cookies'"
+                          / "'unsafe-postmessage-receive'"
+                          / "'unsafe-postmessage-send'"
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-suborigin-policy-list">suborigin-policy-list</dfn> = 1*(<a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3">RWS</a> <a data-link-type="grammar" href="#grammardef-suborigin-policy-option" id="ref-for-grammardef-suborigin-policy-option-1">suborigin-policy-option</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3">OWS</a>)
 <dfn data-dfn-type="grammar" data-export="" id="grammardef-suborigin-header">suborigin-header<a class="self-link" href="#grammardef-suborigin-header"></a></dfn> = <a data-link-type="grammar" href="#grammardef-suborigin-name" id="ref-for-grammardef-suborigin-name-1">suborigin-name</a> [ <a data-link-type="grammar" href="#grammardef-suborigin-policy-list" id="ref-for-grammardef-suborigin-policy-list-1">suborigin-policy-list</a> ]
 </pre>
@@ -1981,6 +1982,32 @@ the '<a data-link-type="dfn" href="#unsafe-cookies" id="ref-for-unsafe-cookies-1
   present in a <a data-link-type="dfn" href="#suborigin-policy" id="ref-for-suborigin-policy-2">suborigin policy</a> have the following effects:</p>
    <ul>
     <li data-md="">
+     <p>'<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unsafe-cookies"><code>unsafe-cookies</code></dfn>' When an execution context with a suborigin
+namespace has <a data-link-type="dfn" href="#unsafe-cookies" id="ref-for-unsafe-cookies-2"><code>unsafe-cookies</code></a> set, the
+execution context should not have a fresh cookie jar for the suborigin
+namespace, and instead, the cookie jar should be shared with the null
+suborigin for the execution context.</p>
+     <p class="issue" id="issue-a4bfe642"><a class="self-link" href="#issue-a4bfe642"></a> TODO(devd): Write an example that makes clear that this is extremely
+dangerous and should not be used if you have Real Deal auth and csrf cookies
+used.</p>
+    <li data-md="">
+     <p>'<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unsafe-postmessage-send"><code>unsafe-postmessage-send</code></dfn>' When a message is sent <i>from</i> a
+suborigin namespace with <a data-link-type="dfn" href="#unsafe-postmessage-send" id="ref-for-unsafe-postmessage-send-1"><code>unsafe-postmessage-send</code></a> set, the <code>event.origin</code> value of the receiver should be set to the serialized
+physical origin, not the serialized suborigin value. However, the <code>event.suborigin</code> field should still be set to the name of the suborigin
+namespace.</p>
+     <div class="example" id="example-4e02913e">
+      <a class="self-link" href="#example-4e02913e"></a> Continuing the case in the above example, <code>https://example.com/maps</code> is a
+mapping application that is commonly embedded in other sites. It provides a <code>postMessage()</code> based API to place locations of the embedder’s choosing on the
+map. <code>httsp://example.com</code> would like to run the application in a suborigin
+named "maps". 
+      <p>In response to queries to the API, <code>https://example.com/maps</code> may send
+messages back to the embedder if, for example, a user clicks on one of the
+locations. However, since the embedder may be legacy and not be aware of
+suborigins, when it checks the <code>event.origin</code> protery of the <code>MesseageEvent</code>, if it sees <code>https-so://maps.example.com</code> as the origin, it
+will reject the message as a potential attack. Thus, <code>https://example.com</code> may use the <a data-link-type="dfn" href="#unsafe-postmessage-send" id="ref-for-unsafe-postmessage-send-2"><code>unsafe-postmessage-send</code></a> directive to allow its messages
+to appear with the origin of the physical origin, in this case <code>https://example.com</code>.</p>
+     </div>
+    <li data-md="">
      <p>'<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unsafe-postmessage-receive"><code>unsafe-postmessage-receive</code></dfn>' When a message is sent <i>to</i> a
 frame with a <code>postMessage</code> <code>target</code> of a serialized physical origin, but not a
 serialized suborigin, if the frame has an execution context with a suborigin
@@ -2000,32 +2027,6 @@ the frame with the <a data-link-type="dfn" href="#unsafe-postmessage-receive" id
 allow the frame to receive messages on behalf of <code>https://example.com</code>, even
 though it is at <code>https-so://maps.example.com</code>.</p>
      </div>
-    <li data-md="">
-     <p>'<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unsafe-postmessage-send"><code>unsafe-postmessage-send</code></dfn>' When a message is sent <i>from</i> a
-suborigin namespace with <a data-link-type="dfn" href="#unsafe-postmessage-send" id="ref-for-unsafe-postmessage-send-1"><code>unsafe-postmessage-send</code></a> set, the <code>event.origin</code> value of the receiver should be set to the serialized
-physical origin, not the serialized suborigin value. However, the <code>event.suborigin</code> field should still be set to the name of the suborigin
-namespace.</p>
-     <div class="example" id="example-4e02913e">
-      <a class="self-link" href="#example-4e02913e"></a> Continuing the case in the above example, <code>https://example.com/maps</code> is a
-mapping application that is commonly embedded in other sites. It provides a <code>postMessage()</code> based API to place locations of the embedder’s choosing on the
-map. <code>httsp://example.com</code> would like to run the application in a suborigin
-named "maps". 
-      <p>In response to queries to the API, <code>https://example.com/maps</code> may send
-messages back to the embedder if, for example, a user clicks on one of the
-locations. However, since the embedder may be legacy and not be aware of
-suborigins, when it checks the <code>event.origin</code> protery of the <code>MesseageEvent</code>, if it sees <code>https-so://maps.example.com</code> as the origin, it
-will reject the message as a potential attack. Thus, <code>https://example.com</code> may use the <a data-link-type="dfn" href="#unsafe-postmessage-send" id="ref-for-unsafe-postmessage-send-2"><code>unsafe-postmessage-send</code></a> directive to allow its messages
-to appear with the origin of the physical origin, in this case <code>https://example.com</code>.</p>
-     </div>
-    <li data-md="">
-     <p>'<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unsafe-cookies"><code>unsafe-cookies</code></dfn>' When an execution context with a suborigin
-namespace has <a data-link-type="dfn" href="#unsafe-cookies" id="ref-for-unsafe-cookies-2"><code>unsafe-cookies</code></a> set, the
-execution context should not have a fresh cookie jar for the suborigin
-namespace, and instead, the cookie jar should be shared with the null
-suborigin for the execution context.</p>
-     <p class="issue" id="issue-a4bfe642"><a class="self-link" href="#issue-a4bfe642"></a> TODO(devd): Write an example that makes clear that this is extremely
-dangerous and should not be used if you have Real Deal auth and csrf cookies
-used.</p>
    </ul>
    <p class="issue" id="issue-01de7cd9"><a class="self-link" href="#issue-01de7cd9"></a> TODO: These opt-out descriptions should probably be moved to the
   individual sections where the behaviors are discussed (i.e. postMessage and
@@ -2349,10 +2350,11 @@ used.<a href="#issue-a4bfe642"> ↵ </a></div>
     <li><a href="#ref-for-suborigin-policy-1">6.5. Security Model Opt-Outs</a> <a href="#ref-for-suborigin-policy-2">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unsafe-postmessage-receive">
-   <b><a href="#unsafe-postmessage-receive">#unsafe-postmessage-receive</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="unsafe-cookies">
+   <b><a href="#unsafe-cookies">#unsafe-cookies</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-unsafe-postmessage-receive-1">6.5. Security Model Opt-Outs</a> <a href="#ref-for-unsafe-postmessage-receive-2">(2)</a>
+    <li><a href="#ref-for-unsafe-cookies-1">6.4.1. Cookies</a>
+    <li><a href="#ref-for-unsafe-cookies-2">6.5. Security Model Opt-Outs</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="unsafe-postmessage-send">
@@ -2361,11 +2363,10 @@ used.<a href="#issue-a4bfe642"> ↵ </a></div>
     <li><a href="#ref-for-unsafe-postmessage-send-1">6.5. Security Model Opt-Outs</a> <a href="#ref-for-unsafe-postmessage-send-2">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unsafe-cookies">
-   <b><a href="#unsafe-cookies">#unsafe-cookies</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="unsafe-postmessage-receive">
+   <b><a href="#unsafe-postmessage-receive">#unsafe-postmessage-receive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-unsafe-cookies-1">6.4.1. Cookies</a>
-    <li><a href="#ref-for-unsafe-cookies-2">6.5. Security Model Opt-Outs</a>
+    <li><a href="#ref-for-unsafe-postmessage-receive-1">6.5. Security Model Opt-Outs</a> <a href="#ref-for-unsafe-postmessage-receive-2">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/index.html
+++ b/index.html
@@ -1363,7 +1363,7 @@ Possible extra rowspan handling
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Suborigins</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-10">10 October 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-04">4 October 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1783,10 +1783,9 @@ This includes providing security-model opt-outs where necessary.</p>
   for the name and value of the header are described by the following ABNF
   grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
 <pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-suborigin-name">suborigin-name</dfn> = 1*( <a data-link-type="grammar" href="#grammardef-loweralpha" id="ref-for-grammardef-loweralpha-1">LOWERALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1">DIGIT</a> / "-" )
-<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-suborigin-policy-option">suborigin-policy-option</dfn> = "'force-include-credentials'"
-                          / "'unsafe-cookies'"
+<dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-suborigin-policy-option">suborigin-policy-option</dfn> = "'unsafe-postmessage-send'"
                           / "'unsafe-postmessage-receive'"
-                          / "'unsafe-postmessage-send'"
+                          / "'unsafe-cookies'"
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-suborigin-policy-list">suborigin-policy-list</dfn> = 1*(<a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3">RWS</a> <a data-link-type="grammar" href="#grammardef-suborigin-policy-option" id="ref-for-grammardef-suborigin-policy-option-1">suborigin-policy-option</a> <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc7230#section-3.2.3">OWS</a>)
 <dfn data-dfn-type="grammar" data-export="" id="grammardef-suborigin-header">suborigin-header<a class="self-link" href="#grammardef-suborigin-header"></a></dfn> = <a data-link-type="grammar" href="#grammardef-suborigin-name" id="ref-for-grammardef-suborigin-name-1">suborigin-name</a> [ <a data-link-type="grammar" href="#grammardef-suborigin-policy-list" id="ref-for-grammardef-suborigin-policy-list-1">suborigin-policy-list</a> ]
 </pre>
@@ -1982,40 +1981,6 @@ the '<a data-link-type="dfn" href="#unsafe-cookies" id="ref-for-unsafe-cookies-1
   present in a <a data-link-type="dfn" href="#suborigin-policy" id="ref-for-suborigin-policy-2">suborigin policy</a> have the following effects:</p>
    <ul>
     <li data-md="">
-     <p>'<dfn data-dfn-type="dfn" data-noexport="" id="force-include-credentials"><code>force-include-credentials</code><a class="self-link" href="#force-include-credentials"></a></dfn>' All cross-origin requests will
-include <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#credentials">credentials</a>. In particular, when this option is set in an
-execution context, all cross-origin <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request">requests</a> from that execution
-context will have their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a> set to "<code>include</code>".  See <a href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
-protocol and credentials</a> for more on including credentials and the
-implications of including credentials in requests.</p>
-     <p class="issue" id="issue-eae464e1"><a class="self-link" href="#issue-eae464e1"></a> TODO(jww): Provide an example of why this might be needed.</p>
-    <li data-md="">
-     <p>'<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unsafe-cookies"><code>unsafe-cookies</code></dfn>' When an execution context with a suborigin
-namespace has <a data-link-type="dfn" href="#unsafe-cookies" id="ref-for-unsafe-cookies-2"><code>unsafe-cookies</code></a> set, the
-execution context should not have a fresh cookie jar for the suborigin
-namespace, and instead, the cookie jar should be shared with the null
-suborigin for the execution context.</p>
-     <p class="issue" id="issue-a4bfe642"><a class="self-link" href="#issue-a4bfe642"></a> TODO(devd): Write an example that makes clear that this is extremely
-dangerous and should not be used if you have Real Deal auth and csrf cookies
-used.</p>
-    <li data-md="">
-     <p>'<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unsafe-postmessage-send"><code>unsafe-postmessage-send</code></dfn>' When a message is sent <i>from</i> a
-suborigin namespace with <a data-link-type="dfn" href="#unsafe-postmessage-send" id="ref-for-unsafe-postmessage-send-1"><code>unsafe-postmessage-send</code></a> set, the <code>event.origin</code> value of the receiver should be set to the serialized
-physical origin, not the serialized suborigin value. However, the <code>event.suborigin</code> field should still be set to the name of the suborigin
-namespace.</p>
-     <div class="example" id="example-b711d6b9">
-      <a class="self-link" href="#example-b711d6b9"></a> <code>https://example.com/maps</code> is a mapping application that is commonly
-embedded in other sites. It provides a <code>postMessage()</code> based API to place
-locations of the embedder’s choosing on the map. <code>https://example.com</code> would
-like to run the application in a suborigin named "maps". 
-      <p>In response to queries to the API, <code>https://example.com/maps</code> may send
-messages back to the embedder if, for example, a user clicks on one of the
-locations. However, since the embedder may be legacy and not be aware of
-suborigins, when it checks the <code>event.origin</code> property of the <code>MesseageEvent</code>, if it sees <code>https-so://maps.example.com</code> as the origin, it
-will reject the message as a potential attack. Thus, <code>https://example.com</code> may use the <a data-link-type="dfn" href="#unsafe-postmessage-send" id="ref-for-unsafe-postmessage-send-2"><code>unsafe-postmessage-send</code></a> directive to allow its messages
-to appear with the origin of the physical origin, in this case <code>https://example.com</code>.</p>
-     </div>
-    <li data-md="">
      <p>'<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unsafe-postmessage-receive"><code>unsafe-postmessage-receive</code></dfn>' When a message is sent <i>to</i> a
 frame with a <code>postMessage</code> <code>target</code> of a serialized physical origin, but not a
 serialized suborigin, if the frame has an execution context with a suborigin
@@ -2023,10 +1988,9 @@ where the scheme, host, and port match the <code>target</code>, but it also has 
 suborigin namespace, if <a data-link-type="dfn" href="#unsafe-postmessage-receive" id="ref-for-unsafe-postmessage-receive-1"><code>unsafe-postmessage-receive</code></a> is set, it will
 still receive the message.</p>
      <div class="example" id="unsafe-postmessage-send-ex">
-      <a class="self-link" href="#unsafe-postmessage-send-ex"></a> Continuing the example from above, assume <code>https://example.com</code> runs a map
-API at <code>https://example.com/maps</code> which is embedded by many other websites.
-It provides a <code>postMessage()</code> API to place markers on the map at locations
-the embedder chooses. 
+      <a class="self-link" href="#unsafe-postmessage-send-ex"></a> <code>https://example.com</code> runs a map API at <code>https://example.com/maps</code> which is
+embedded by many other websites. It provides a <code>postMessage()</code> API to place
+markers on the map at locations the embedder chooses. 
       <p>The developer would like to run <code>https://example.com/maps</code> in a suborigin
 namespace "maps".  However, when embedders send messages to the embedded
 frame, because they are legacy uses from before the use of suborigins, they
@@ -2036,6 +2000,32 @@ the frame with the <a data-link-type="dfn" href="#unsafe-postmessage-receive" id
 allow the frame to receive messages on behalf of <code>https://example.com</code>, even
 though it is at <code>https-so://maps.example.com</code>.</p>
      </div>
+    <li data-md="">
+     <p>'<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unsafe-postmessage-send"><code>unsafe-postmessage-send</code></dfn>' When a message is sent <i>from</i> a
+suborigin namespace with <a data-link-type="dfn" href="#unsafe-postmessage-send" id="ref-for-unsafe-postmessage-send-1"><code>unsafe-postmessage-send</code></a> set, the <code>event.origin</code> value of the receiver should be set to the serialized
+physical origin, not the serialized suborigin value. However, the <code>event.suborigin</code> field should still be set to the name of the suborigin
+namespace.</p>
+     <div class="example" id="example-4e02913e">
+      <a class="self-link" href="#example-4e02913e"></a> Continuing the case in the above example, <code>https://example.com/maps</code> is a
+mapping application that is commonly embedded in other sites. It provides a <code>postMessage()</code> based API to place locations of the embedder’s choosing on the
+map. <code>httsp://example.com</code> would like to run the application in a suborigin
+named "maps". 
+      <p>In response to queries to the API, <code>https://example.com/maps</code> may send
+messages back to the embedder if, for example, a user clicks on one of the
+locations. However, since the embedder may be legacy and not be aware of
+suborigins, when it checks the <code>event.origin</code> protery of the <code>MesseageEvent</code>, if it sees <code>https-so://maps.example.com</code> as the origin, it
+will reject the message as a potential attack. Thus, <code>https://example.com</code> may use the <a data-link-type="dfn" href="#unsafe-postmessage-send" id="ref-for-unsafe-postmessage-send-2"><code>unsafe-postmessage-send</code></a> directive to allow its messages
+to appear with the origin of the physical origin, in this case <code>https://example.com</code>.</p>
+     </div>
+    <li data-md="">
+     <p>'<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unsafe-cookies"><code>unsafe-cookies</code></dfn>' When an execution context with a suborigin
+namespace has <a data-link-type="dfn" href="#unsafe-cookies" id="ref-for-unsafe-cookies-2"><code>unsafe-cookies</code></a> set, the
+execution context should not have a fresh cookie jar for the suborigin
+namespace, and instead, the cookie jar should be shared with the null
+suborigin for the execution context.</p>
+     <p class="issue" id="issue-a4bfe642"><a class="self-link" href="#issue-a4bfe642"></a> TODO(devd): Write an example that makes clear that this is extremely
+dangerous and should not be used if you have Real Deal auth and csrf cookies
+used.</p>
    </ul>
    <p class="issue" id="issue-01de7cd9"><a class="self-link" href="#issue-01de7cd9"></a> TODO: These opt-out descriptions should probably be moved to the
   individual sections where the behaviors are discussed (i.e. postMessage and
@@ -2119,7 +2109,6 @@ though it is at <code>https-so://maps.example.com</code>.</p>
    <li><a href="#cross-origin">cross-origin</a><span>, in §2</span>
    <li><a href="#cross-origin-resource-sharing">Cross-Origin Resource Sharing</a><span>, in §2</span>
    <li><a href="#cross-site-scripting">cross-site scripting</a><span>, in §2</span>
-   <li><a href="#force-include-credentials">force-include-credentials</a><span>, in §6.5</span>
    <li><a href="#grammardef-loweralpha">LOWERALPHA</a><span>, in §2.1</span>
    <li><a href="#origin">origin</a><span>, in §2</span>
    <li><a href="#physical-origin">physical origin</a><span>, in §3.4</span>
@@ -2161,10 +2150,7 @@ though it is at <code>https-so://maps.example.com</code>.</p>
    <li>
     <a data-link-type="biblio">[FETCH]</a> defines the following terms:
     <ul>
-     <li><a href="https://fetch.spec.whatwg.org#credentials">credentials</a>
-     <li><a href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a>
      <li><a href="https://fetch.spec.whatwg.org#concept-fetch">fetch</a>
-     <li><a href="https://fetch.spec.whatwg.org#concept-request">request</a>
     </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
@@ -2268,7 +2254,6 @@ though it is at <code>https-so://maps.example.com</code>.</p>
    <div class="issue"> TODO: This section should probably be broken up. At the very least,
   needs to be formalized. Maybe just stick with creating a new execution
   context, and then carving out the weird exceptions?<a href="#issue-73e47fd0"> ↵ </a></div>
-   <div class="issue"> TODO(jww): Provide an example of why this might be needed.<a href="#issue-eae464e1"> ↵ </a></div>
    <div class="issue"> TODO(devd): Write an example that makes clear that this is extremely
 dangerous and should not be used if you have Real Deal auth and csrf cookies
 used.<a href="#issue-a4bfe642"> ↵ </a></div>
@@ -2364,11 +2349,10 @@ used.<a href="#issue-a4bfe642"> ↵ </a></div>
     <li><a href="#ref-for-suborigin-policy-1">6.5. Security Model Opt-Outs</a> <a href="#ref-for-suborigin-policy-2">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unsafe-cookies">
-   <b><a href="#unsafe-cookies">#unsafe-cookies</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="unsafe-postmessage-receive">
+   <b><a href="#unsafe-postmessage-receive">#unsafe-postmessage-receive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-unsafe-cookies-1">6.4.1. Cookies</a>
-    <li><a href="#ref-for-unsafe-cookies-2">6.5. Security Model Opt-Outs</a>
+    <li><a href="#ref-for-unsafe-postmessage-receive-1">6.5. Security Model Opt-Outs</a> <a href="#ref-for-unsafe-postmessage-receive-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="unsafe-postmessage-send">
@@ -2377,10 +2361,11 @@ used.<a href="#issue-a4bfe642"> ↵ </a></div>
     <li><a href="#ref-for-unsafe-postmessage-send-1">6.5. Security Model Opt-Outs</a> <a href="#ref-for-unsafe-postmessage-send-2">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unsafe-postmessage-receive">
-   <b><a href="#unsafe-postmessage-receive">#unsafe-postmessage-receive</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="unsafe-cookies">
+   <b><a href="#unsafe-cookies">#unsafe-cookies</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-unsafe-postmessage-receive-1">6.5. Security Model Opt-Outs</a> <a href="#ref-for-unsafe-postmessage-receive-2">(2)</a>
+    <li><a href="#ref-for-unsafe-cookies-1">6.4.1. Cookies</a>
+    <li><a href="#ref-for-unsafe-cookies-2">6.5. Security Model Opt-Outs</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/index.html
+++ b/index.html
@@ -1983,10 +1983,11 @@ the '<a data-link-type="dfn" href="#unsafe-cookies" id="ref-for-unsafe-cookies-1
    <ul>
     <li data-md="">
      <p>'<dfn data-dfn-type="dfn" data-noexport="" id="force-include-credentials"><code>force-include-credentials</code><a class="self-link" href="#force-include-credentials"></a></dfn>' All cross-origin requests will
-include <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#credentials">credentials</a>. In particular, when this option is set, all
-cross-origin <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request">requests</a> will have their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a> set to
-"<code>include</code>".  See <a href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
-protocol and credentials</a> for more on including credentials.</p>
+include <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#credentials">credentials</a>. In particular, when this option is set in an
+execution context, all cross-origin <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request">requests</a> from that execution
+context will have their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a> set to "<code>include</code>".  See <a href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
+protocol and credentials</a> for more on including credentials and the
+implications of including credentials in requests.</p>
      <p class="issue" id="issue-eae464e1"><a class="self-link" href="#issue-eae464e1"></a> TODO(jww): Provide an example of why this might be needed.</p>
     <li data-md="">
      <p>'<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unsafe-cookies"><code>unsafe-cookies</code></dfn>' When an execution context with a suborigin

--- a/index.html
+++ b/index.html
@@ -2033,7 +2033,9 @@ used.</p>
  the <a data-link-type="dfn" href="#physical-origin" id="ref-for-physical-origin-3">physical origin</a> will have their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a> set to
  "<code>include</code>". Additionally, if the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a> is
  programmitically set, it will still be overriden to be set to "<code>include</code>".</p>
-     <p>See <a href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
+     <p class="note" role="note">Note: This applies to <em>all</em> cross-origin requests, not just <code>xmlHttpRequests</code> and <code>fetch</code> requests. Thus all cross-origin elements on
+ the page, including, for example, image tags, will have the equivalement of
+ the <code>crossorigin</code> attribute set to "<code>use-credentials</code>". See <a href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
  protocol and credentials</a> for more on including credentials and the
  implications of including credentials in requests.</p>
      <p class="issue" id="issue-ec925137"><a class="self-link" href="#issue-ec925137"></a> TODO(jww,aaj): Provide an example of why this might be needed.</p>

--- a/index.html
+++ b/index.html
@@ -1982,6 +1982,11 @@ the '<a data-link-type="dfn" href="#unsafe-cookies" id="ref-for-unsafe-cookies-1
   present in a <a data-link-type="dfn" href="#suborigin-policy" id="ref-for-suborigin-policy-2">suborigin policy</a> have the following effects:</p>
    <ul>
     <li data-md="">
+     <p>'<dfn data-dfn-type="dfn" data-noexport="" id="force-include-credentials"><code>force-include-credentials</code><a class="self-link" href="#force-include-credentials"></a></dfn>' All cross-origin requests will
+include <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#credentials">credentials</a>. In particular, when this option is set, all <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request">requests</a> will have their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a> set to "<code>include</code>".
+See <a href="https://fetch.spec.whatwg.org/#cors-protocol-and-credentials">CORS
+protocol and credentials</a> for mor</p>
+    <li data-md="">
      <p>'<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unsafe-cookies"><code>unsafe-cookies</code></dfn>' When an execution context with a suborigin
 namespace has <a data-link-type="dfn" href="#unsafe-cookies" id="ref-for-unsafe-cookies-2"><code>unsafe-cookies</code></a> set, the
 execution context should not have a fresh cookie jar for the suborigin
@@ -1995,15 +2000,15 @@ used.</p>
 suborigin namespace with <a data-link-type="dfn" href="#unsafe-postmessage-send" id="ref-for-unsafe-postmessage-send-1"><code>unsafe-postmessage-send</code></a> set, the <code>event.origin</code> value of the receiver should be set to the serialized
 physical origin, not the serialized suborigin value. However, the <code>event.suborigin</code> field should still be set to the name of the suborigin
 namespace.</p>
-     <div class="example" id="example-4e02913e">
-      <a class="self-link" href="#example-4e02913e"></a> Continuing the case in the above example, <code>https://example.com/maps</code> is a
-mapping application that is commonly embedded in other sites. It provides a <code>postMessage()</code> based API to place locations of the embedder’s choosing on the
-map. <code>httsp://example.com</code> would like to run the application in a suborigin
-named "maps". 
+     <div class="example" id="example-231b0547">
+      <a class="self-link" href="#example-231b0547"></a> Continuing the case in the above example, <code>https://example.com/maps</code> is a
+mapping application that is commonly embedded in other sites. It provides a <code>postMessage()</code> based API to place locations of the embedder’s
+choosing on the map. <code>https://example.com</code> would like to run the application
+in a suborigin named "maps". 
       <p>In response to queries to the API, <code>https://example.com/maps</code> may send
 messages back to the embedder if, for example, a user clicks on one of the
 locations. However, since the embedder may be legacy and not be aware of
-suborigins, when it checks the <code>event.origin</code> protery of the <code>MesseageEvent</code>, if it sees <code>https-so://maps.example.com</code> as the origin, it
+suborigins, when it checks the <code>event.origin</code> property of the <code>MesseageEvent</code>, if it sees <code>https-so://maps.example.com</code> as the origin, it
 will reject the message as a potential attack. Thus, <code>https://example.com</code> may use the <a data-link-type="dfn" href="#unsafe-postmessage-send" id="ref-for-unsafe-postmessage-send-2"><code>unsafe-postmessage-send</code></a> directive to allow its messages
 to appear with the origin of the physical origin, in this case <code>https://example.com</code>.</p>
      </div>
@@ -2110,6 +2115,7 @@ though it is at <code>https-so://maps.example.com</code>.</p>
    <li><a href="#cross-origin">cross-origin</a><span>, in §2</span>
    <li><a href="#cross-origin-resource-sharing">Cross-Origin Resource Sharing</a><span>, in §2</span>
    <li><a href="#cross-site-scripting">cross-site scripting</a><span>, in §2</span>
+   <li><a href="#force-include-credentials">force-include-credentials</a><span>, in §6.5</span>
    <li><a href="#grammardef-loweralpha">LOWERALPHA</a><span>, in §2.1</span>
    <li><a href="#origin">origin</a><span>, in §2</span>
    <li><a href="#physical-origin">physical origin</a><span>, in §3.4</span>
@@ -2151,7 +2157,10 @@ though it is at <code>https-so://maps.example.com</code>.</p>
    <li>
     <a data-link-type="biblio">[FETCH]</a> defines the following terms:
     <ul>
+     <li><a href="https://fetch.spec.whatwg.org#credentials">credentials</a>
+     <li><a href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">credentials mode</a>
      <li><a href="https://fetch.spec.whatwg.org#concept-fetch">fetch</a>
+     <li><a href="https://fetch.spec.whatwg.org#concept-request">request</a>
     </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:


### PR DESCRIPTION
@devd can you review this update? This adds a new option flag per the discussion in #33 to force include credentials on all cross-origin requests. You can also see the compiled version at https://metromoxie.github.io/webappsec-suborigins/.