### PR TITLE
Suborigin names can only start with letters.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -461,7 +461,7 @@ spec: XHR; urlPrefix: https://xhr.spec.whatwg.org/
   grammar [[!RFC5234]]:
 
   <pre dfn-type="grammar" link-type="grammar">
-      <dfn>suborigin-name</dfn> = 1*( <a>LOWERALPHA</a> / <a>DIGIT</a> / "-" )
+      <dfn>suborigin-name</dfn> = <a>LOWERALPHA</a> *( <a>LOWERALPHA</a> / <a>DIGIT</a> )
       <dfn>suborigin-policy-option</dfn> = "'unsafe-postmessage-send'"
                                 / "'unsafe-postmessage-receive'"
                                 / "'unsafe-cookies'"
@@ -478,6 +478,12 @@ spec: XHR; urlPrefix: https://xhr.spec.whatwg.org/
   A resource's <dfn>suborigin policy</dfn> is the list of individual
   <a link-type="grammar">suborigin-policy-option</a> values in the `suborigin`
   header's  <a link-type="grammar">suborigin-policy-list</a>.
+
+  Note: A suborigin name must start with a lowercase character, but after the
+  first character, the name may contain lowercase characters or numerals. This
+  is to avoid potential confusion when the origin is serialized if the
+  serialization started with a number.
+
   ## Accessing the Suborigin in JavaScript ## {#suborigin-in-js}
 
   A `suborigin` property is added to the <a>document</a> object which

--- a/index.html
+++ b/index.html
@@ -1363,7 +1363,7 @@ Possible extra rowspan handling
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Suborigins</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-26">26 October 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-10-27">27 October 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1797,7 +1797,7 @@ This includes providing security-model opt-outs where necessary.</p>
    <p>Suborigins are defined by a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="suborigin">suborigin</dfn> HTTP response header. The syntax
   for the name and value of the header are described by the following ABNF
   grammar <a data-link-type="biblio" href="#biblio-rfc5234">[RFC5234]</a>:</p>
-<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-suborigin-name">suborigin-name</dfn> = 1*( <a data-link-type="grammar" href="#grammardef-loweralpha" id="ref-for-grammardef-loweralpha-1">LOWERALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1">DIGIT</a> / "-" )
+<pre><dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-suborigin-name">suborigin-name</dfn> = <a data-link-type="grammar" href="#grammardef-loweralpha" id="ref-for-grammardef-loweralpha-1">LOWERALPHA</a> *( <a data-link-type="grammar" href="#grammardef-loweralpha" id="ref-for-grammardef-loweralpha-2">LOWERALPHA</a> / <a data-link-type="grammar" href="https://tools.ietf.org/html/rfc5234#appendix-B.1">DIGIT</a> )
 <dfn class="dfn-paneled" data-dfn-type="grammar" data-export="" id="grammardef-suborigin-policy-option">suborigin-policy-option</dfn> = "'unsafe-postmessage-send'"
                           / "'unsafe-postmessage-receive'"
                           / "'unsafe-cookies'"
@@ -1808,6 +1808,10 @@ This includes providing security-model opt-outs where necessary.</p>
    <p>User agents MUST ignore multiple suborigin headers and only apply the first.</p>
    <p>A resource’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="suborigin-namespace">suborigin namespace</dfn> is the value of the <a data-link-type="grammar" href="#grammardef-suborigin-name" id="ref-for-grammardef-suborigin-name-2">suborigin-name</a> in the <code>suborigin</code> header.</p>
    <p>A resource’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="suborigin-policy">suborigin policy</dfn> is the list of individual <a data-link-type="grammar" href="#grammardef-suborigin-policy-option" id="ref-for-grammardef-suborigin-policy-option-2">suborigin-policy-option</a> values in the <code>suborigin</code> header’s <a data-link-type="grammar" href="#grammardef-suborigin-policy-list" id="ref-for-grammardef-suborigin-policy-list-2">suborigin-policy-list</a>.</p>
+   <p class="note" role="note">Note: A suborigin name must start with a lowercase character, but after the
+  first character, the name may contain lowercase characters or numerals. This
+  is to avoid potential confusion when the origin is serialized if the
+  serialization started with a number.</p>
    <h3 class="heading settled" data-level="3.7" id="suborigin-in-js"><span class="secno">3.7. </span><span class="content">Accessing the Suborigin in JavaScript</span><a class="self-link" href="#suborigin-in-js"></a></h3>
    <p>A <code>suborigin</code> property is added to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document">document</a> object which <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-reflect">reflects</a> the value of the suborigin namespace for the current execution
   context. If there is no suborigin namespace, the value should be undefined.</p>
@@ -2383,7 +2387,7 @@ otherwise.</p>
   <aside class="dfn-panel" data-for="grammardef-loweralpha">
    <b><a href="#grammardef-loweralpha">#grammardef-loweralpha</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-loweralpha-1">3.6. The suborigin header</a>
+    <li><a href="#ref-for-grammardef-loweralpha-1">3.6. The suborigin header</a> <a href="#ref-for-grammardef-loweralpha-2">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="suborigin">


### PR DESCRIPTION
@devd, can you take a look (available for viewing at https://metromoxie.github.io/webappsec-suborigins/)? This is meant to start addressing #47. In particular, this change:
* Requires that suborigin names start with a letter. However, it does _not_ ban numbers for the 2nd character onward. I'm very sympathetic to the use case listed in #47, and it seems that allowing easy base 32 encoding would be extremely useful (e.g. encoding hashes in the suborigin name). That having been said, we'll still need to do a more thorough review per @annevk's suggestion to make sure that's a safe thing to do in all contexts.
* It adds an allowed suborigin name value of `'null'` in the header which is meant to be equivalent to not providing a suborigin name at all. This serves two purposes: (1) if we need to send suborigin headers even if a suborigin isn't explicitly assigned, this allows that more easily, and (2) it allows policies to be set even if there isn't a suborigin. Neither one of these is explicitly useful in this version of the spec, but I don't want to outright disallow them.